### PR TITLE
Add User-Agent to the GET request

### DIFF
--- a/check.py
+++ b/check.py
@@ -413,7 +413,7 @@ def checkPolicyFile(result, domain):
         return result.error('connect')
 
     try:
-        conn.request('GET', path)
+        conn.request('GET', path, headers={"User-Agent": "mta-sts (https://github.com/aykevl/mta-sts)"})
         res = conn.getresponse()
         if res.status == 404:
             return result.error('policy-not-found')


### PR DESCRIPTION
It is best practice to include a User-Agent and some servers block
requests without a User-Agent.